### PR TITLE
Add animated player and basic room traversal

### DIFF
--- a/Assets/Scripts/CameraFollow.cs
+++ b/Assets/Scripts/CameraFollow.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+public class CameraFollow : MonoBehaviour
+{
+    public Transform target;
+    public static CameraFollow instance;
+
+    void Awake()
+    {
+        instance = this;
+    }
+
+    void LateUpdate()
+    {
+        if (target != null)
+        {
+            transform.position = new Vector3(target.position.x, target.position.y, transform.position.z);
+        }
+    }
+}

--- a/Assets/Scripts/CameraFollow.cs.meta
+++ b/Assets/Scripts/CameraFollow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63c223a4c22143679ecae0b8d8576f51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Door.cs
+++ b/Assets/Scripts/Door.cs
@@ -1,13 +1,56 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class Door : MonoBehaviour
 {
     public SpriteRenderer spriteRenderer;
+    private EdgeDirection direction;
+
+    private void Awake()
+    {
+        var col = GetComponent<Collider2D>();
+        if (col == null)
+        {
+            var box = gameObject.AddComponent<BoxCollider2D>();
+            box.isTrigger = true;
+        }
+    }
 
     public void SetDoorSprite(Sprite door)
     {
         spriteRenderer.sprite = door;
+    }
+
+    public void SetDirection(EdgeDirection dir)
+    {
+        direction = dir;
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        var player = other.GetComponent<PlayerController>();
+        if (player == null) return;
+
+        Vector2 offset = Vector2.zero;
+        Vector2 push = Vector2.zero;
+        switch (direction)
+        {
+            case EdgeDirection.Up:
+                offset = new Vector2(0, RoomManager.instance.offsetY);
+                push = Vector2.up;
+                break;
+            case EdgeDirection.Down:
+                offset = new Vector2(0, -RoomManager.instance.offsetY);
+                push = Vector2.down;
+                break;
+            case EdgeDirection.Left:
+                offset = new Vector2(-RoomManager.instance.offsetX, 0);
+                push = Vector2.left;
+                break;
+            case EdgeDirection.Right:
+                offset = new Vector2(RoomManager.instance.offsetX, 0);
+                push = Vector2.right;
+                break;
+        }
+        player.transform.position += (Vector3)(offset + push);
     }
 }

--- a/Assets/Scripts/MapGenerator.cs
+++ b/Assets/Scripts/MapGenerator.cs
@@ -28,6 +28,7 @@ public class MapGenerator : MonoBehaviour
     public List<Cell> getSpawnedCells => spawnedCells;
 
     private List<int> bigRoomIndexes;
+    private GameObject playerInstance;
 
     [Header("Sprite References")]
     [SerializeField] private Sprite item;
@@ -149,7 +150,7 @@ public class MapGenerator : MonoBehaviour
         endRooms.RemoveAll(item => bigRoomIndexes.Contains(item) || GetNeighbourCount(item) > 1);
     }
 
-    void SetupSpecialRooms() 
+    void SetupSpecialRooms()
     {
         bossRoomIndex = endRooms.Count > 0 ? endRooms[endRooms.Count - 1] : -1;
 
@@ -172,6 +173,18 @@ public class MapGenerator : MonoBehaviour
 
         UpdateSpecialRoomVisuals();
         RoomManager.instance.SetupRooms(spawnedCells);
+        SpawnPlayer();
+    }
+
+    void SpawnPlayer()
+    {
+        if (playerInstance == null)
+        {
+            playerInstance = PlayerController.Create();
+            if (CameraFollow.instance != null)
+                CameraFollow.instance.target = playerInstance.transform;
+        }
+        playerInstance.transform.position = Vector2.zero;
     }
 
     void UpdateSpecialRoomVisuals() 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -1,0 +1,75 @@
+using System;
+using UnityEngine;
+
+public class PlayerController : MonoBehaviour
+{
+    public float speed = 5f;
+
+    private Rigidbody2D rb;
+    private SpriteRenderer sr;
+    private Sprite[] frames;
+    private int direction; //0-down,1-left,2-right,3-up
+    private int animFrame;
+    private float animTimer;
+
+    private static readonly string spriteBase64 = "iVBORw0KGgoAAAANSUhEUgAAAIAAAAAQCAYAAADeWHeIAAAAiElEQVR4nO3VSwqAMAxF0ex/Zd1VxYGD2rQEkb5+7gNx4klD0GhGCCGE+MkpZfxh/katC7+57+FIEfzaXt4AvniuuI/w0wzg3fRo7xipHzL/CO4Vwa/tw0Wa+EdvbADJ/OX/IPUATvfyBvDiF+ApYvVXG8NWr2ELrj/On+N8r5nPwa/tCSE75wL1jq4JKFYPCQAAAABJRU5ErkJggg==";
+
+    public static GameObject Create()
+    {
+        var go = new GameObject("Player");
+        go.AddComponent<PlayerController>();
+        return go;
+    }
+
+    void Awake()
+    {
+        rb = gameObject.AddComponent<Rigidbody2D>();
+        rb.gravityScale = 0;
+        rb.constraints = RigidbodyConstraints2D.FreezeRotation;
+        sr = gameObject.AddComponent<SpriteRenderer>();
+        LoadSprites();
+    }
+
+    void LoadSprites()
+    {
+        var bytes = Convert.FromBase64String(spriteBase64);
+        var tex = new Texture2D(0, 0) { filterMode = FilterMode.Point };
+        tex.LoadImage(bytes);
+
+        frames = new Sprite[8];
+        int w = 16; int h = 16;
+        for (int i = 0; i < 8; i++)
+        {
+            frames[i] = Sprite.Create(tex, new Rect(i * w, 0, w, h), new Vector2(0.5f, 0.5f), 16);
+        }
+        sr.sprite = frames[0];
+    }
+
+    void Update()
+    {
+        Vector2 input = new Vector2(Input.GetAxisRaw("Horizontal"), Input.GetAxisRaw("Vertical"));
+        input = input.normalized;
+        rb.velocity = input * speed;
+
+        if (input != Vector2.zero)
+        {
+            if (Mathf.Abs(input.x) > Mathf.Abs(input.y))
+                direction = input.x > 0 ? 2 : 1;
+            else
+                direction = input.y > 0 ? 3 : 0;
+
+            animTimer += Time.deltaTime;
+            if (animTimer > 0.2f)
+            {
+                animFrame = 1 - animFrame;
+                animTimer = 0f;
+            }
+        }
+        else
+        {
+            animFrame = 0;
+        }
+
+        sr.sprite = frames[direction * 2 + animFrame];
+    }
+}

--- a/Assets/Scripts/PlayerController.cs.meta
+++ b/Assets/Scripts/PlayerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efe1c6d4abe241868ffd79d53cc47ada
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Room.cs
+++ b/Assets/Scripts/Room.cs
@@ -214,6 +214,8 @@ public class Room : MonoBehaviour
             default:
                 break;
         }
+
+        door.SetDirection(direction);
     }
 
     private DoorScriptable GetDoorOptions(RoomType roomType)


### PR DESCRIPTION
## Summary
- Introduce `PlayerController` that spawns an animated hero from an embedded Base64 sprite and handles top-down movement
- Follow the player with a lightweight `CameraFollow` component and wire it from the map generator
- Enable door triggers to move the player between connected rooms
- Replace binary sprite asset with a text representation to allow PR creation

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c02913bec4833188576caccbbb7abe