### PR TITLE
Add start room guidance, enemies, and room interactions

### DIFF
--- a/Assets/Scripts/CameraFollow.cs
+++ b/Assets/Scripts/CameraFollow.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+public class CameraFollow : MonoBehaviour
+{
+    public Transform target;
+    public static CameraFollow instance;
+
+    void Awake()
+    {
+        instance = this;
+    }
+
+    void LateUpdate()
+    {
+        if (target != null)
+        {
+            transform.position = new Vector3(target.position.x, target.position.y, transform.position.z);
+        }
+    }
+}

--- a/Assets/Scripts/CameraFollow.cs.meta
+++ b/Assets/Scripts/CameraFollow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63c223a4c22143679ecae0b8d8576f51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Door.cs
+++ b/Assets/Scripts/Door.cs
@@ -1,13 +1,90 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class Door : MonoBehaviour
 {
     public SpriteRenderer spriteRenderer;
+    private int sourceIndex;
+    private int targetIndex;
+    private EdgeDirection direction;
+
+    private void Awake()
+    {
+        var col = GetComponent<Collider2D>();
+        if (col == null)
+        {
+            var box = gameObject.AddComponent<BoxCollider2D>();
+            box.isTrigger = true;
+        }
+    }
 
     public void SetDoorSprite(Sprite door)
     {
         spriteRenderer.sprite = door;
+    }
+
+    public void SetConnection(int fromIndex, int toIndex)
+    {
+        sourceIndex = fromIndex;
+        targetIndex = toIndex;
+    }
+
+    public Vector2 GetSize()
+    {
+        if (spriteRenderer == null || spriteRenderer.sprite == null)
+            return Vector2.one;
+
+        var bounds = spriteRenderer.sprite.bounds.size;
+        var lossy = transform.lossyScale;
+        return new Vector2(bounds.x * lossy.x, bounds.y * lossy.y);
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        var player = other.GetComponent<PlayerController>();
+        if (player == null) return;
+
+        if (!RoomManager.instance.TryGetRoom(targetIndex, out _))
+            return;
+
+        var destination = RoomManager.instance.GetRoomCenter(targetIndex);
+        var offset = GetEntryOffset();
+        player.transform.position = destination + offset;
+
+        var body = player.GetComponent<Rigidbody2D>();
+        if (body != null)
+        {
+            body.velocity = Vector2.zero;
+        }
+
+        if (player.CurrentRoomIndex != sourceIndex)
+        {
+            player.SetCurrentRoom(sourceIndex);
+        }
+
+        player.SetCurrentRoom(targetIndex);
+        RoomManager.instance.NotifyPlayerEntered(targetIndex, player);
+    }
+
+    public void SetDirection(EdgeDirection dir)
+    {
+        direction = dir;
+    }
+
+    private Vector2 GetEntryOffset()
+    {
+        const float offsetAmount = 1.25f;
+        switch (direction)
+        {
+            case EdgeDirection.Up:
+                return Vector2.down * offsetAmount;
+            case EdgeDirection.Down:
+                return Vector2.up * offsetAmount;
+            case EdgeDirection.Left:
+                return Vector2.right * offsetAmount;
+            case EdgeDirection.Right:
+                return Vector2.left * offsetAmount;
+            default:
+                return Vector2.zero;
+        }
     }
 }

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -1,0 +1,80 @@
+using System;
+using UnityEngine;
+
+public class EnemyController : MonoBehaviour
+{
+    [SerializeField] private float moveSpeed = 2f;
+
+    private Transform player;
+    private Rect movementBounds;
+    private bool active;
+    private SpriteRenderer spriteRenderer;
+    private static Sprite cachedSprite;
+
+    public static EnemyController Create()
+    {
+        var go = new GameObject("Enemy");
+        var enemy = go.AddComponent<EnemyController>();
+        enemy.InitializeGraphics();
+        return enemy;
+    }
+
+    private void InitializeGraphics()
+    {
+        spriteRenderer = gameObject.AddComponent<SpriteRenderer>();
+        spriteRenderer.sprite = GetEnemySprite();
+        spriteRenderer.sortingOrder = 5;
+
+        var collider = gameObject.AddComponent<CircleCollider2D>();
+        collider.isTrigger = true;
+        collider.radius = 0.35f;
+    }
+
+    private Sprite GetEnemySprite()
+    {
+        if (cachedSprite != null)
+            return cachedSprite;
+
+        const string data = "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABpklEQVR42mNkAAKGuP///7+18A1mBjaz8P/PYprPgNZAFgcSgwgXQC+BwR6G/6PjP9T+y+4/ysb43+ZGJgY/v//D0P/f5gZGJgYgLEgB2D+H2T4b0v3n2DG9Z/DXxgYGAaA8SAXYP4/5PhvRPfP4Ib1n8NfGBgYBoDxIBdg/j+E+F9L9z9gxvWfw18YGBgGgPEgF2D+P8T4X0v3P2DG9Z/DXxgYGAaA8SAXYP4/xPjfG3n2DG9Z/DXxgYGAaA8SAXYP4/wvxfSfefYMZ1n8NfGBgYBoDxIBdg/j/C/F9J95/gxvWfw18YGNgYBDL+Z4b8x+a8f2PjP5/5BhYGNjAwMt/P2D2f2T4n4z/f+QYGBgY2MDAn38/YPe/0+F+M/3/kGBgYGNjAwJ9/P2H3v1PhfjP9/5BgYGBjYwMCffz9g979T4X4z/f+QYGBrY9B+1/28w8r+b8f8PhvofsPxPxvxnw+E+h+w/E/G/GfD4T6H7D8T8b8Z8PhPofEPMAAAcYB2t57lGCNAAAAAElFTkSuQmCC";
+        var bytes = Convert.FromBase64String(data);
+        var tex = new Texture2D(0, 0) { filterMode = FilterMode.Point };
+        tex.LoadImage(bytes);
+        cachedSprite = Sprite.Create(tex, new Rect(0, 0, tex.width, tex.height), new Vector2(0.5f, 0.5f), tex.width);
+        return cachedSprite;
+    }
+
+    public void Configure(Transform playerTarget, Rect bounds)
+    {
+        player = playerTarget;
+        movementBounds = bounds;
+        active = true;
+    }
+
+    private void Update()
+    {
+        if (!active || player == null)
+            return;
+
+        var toPlayer = (Vector2)(player.position - transform.position);
+        if (toPlayer.sqrMagnitude > 0.0001f)
+        {
+            var direction = toPlayer.normalized;
+            transform.position += (Vector3)(direction * moveSpeed * Time.deltaTime);
+        }
+
+        var position = transform.position;
+        position.x = Mathf.Clamp(position.x, movementBounds.xMin, movementBounds.xMax);
+        position.y = Mathf.Clamp(position.y, movementBounds.yMin, movementBounds.yMax);
+        transform.position = position;
+    }
+
+    public void SetActive(bool shouldBeActive)
+    {
+        active = shouldBeActive;
+    }
+
+    public void TakeDamage()
+    {
+        Destroy(gameObject);
+    }
+}

--- a/Assets/Scripts/EnemyController.cs.meta
+++ b/Assets/Scripts/EnemyController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ce15600adc54594a1756e674abd53d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/InstructionOverlay.cs
+++ b/Assets/Scripts/InstructionOverlay.cs
@@ -1,0 +1,71 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class InstructionOverlay : MonoBehaviour
+{
+    private static InstructionOverlay instance;
+
+    private GameObject panel;
+    private Text instructionText;
+
+    private void Awake()
+    {
+        instance = this;
+        DontDestroyOnLoad(gameObject);
+        BuildUI();
+        Hide();
+    }
+
+    private void BuildUI()
+    {
+        var canvas = gameObject.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        gameObject.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+        gameObject.AddComponent<GraphicRaycaster>();
+
+        panel = new GameObject("Panel");
+        panel.transform.SetParent(transform, false);
+        var image = panel.AddComponent<Image>();
+        image.color = new Color(0f, 0f, 0f, 0.6f);
+
+        var rect = image.rectTransform;
+        rect.anchorMin = new Vector2(0.02f, 0.72f);
+        rect.anchorMax = new Vector2(0.42f, 0.97f);
+        rect.offsetMin = Vector2.zero;
+        rect.offsetMax = Vector2.zero;
+
+        var textObject = new GameObject("Instructions");
+        textObject.transform.SetParent(panel.transform, false);
+        instructionText = textObject.AddComponent<Text>();
+        instructionText.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        instructionText.color = Color.white;
+        instructionText.alignment = TextAnchor.UpperLeft;
+        instructionText.fontSize = 26;
+        instructionText.text = "WASD = move\nArrow Keys = shoot projectile\nWalk into chest to open it";
+
+        var textRect = instructionText.rectTransform;
+        textRect.anchorMin = new Vector2(0.05f, 0.05f);
+        textRect.anchorMax = new Vector2(0.95f, 0.95f);
+        textRect.offsetMin = Vector2.zero;
+        textRect.offsetMax = Vector2.zero;
+    }
+
+    public static void Show()
+    {
+        EnsureInstance();
+        instance.panel.SetActive(true);
+    }
+
+    public static void Hide()
+    {
+        if (instance == null) return;
+        instance.panel.SetActive(false);
+    }
+
+    private static void EnsureInstance()
+    {
+        if (instance != null) return;
+        var go = new GameObject("InstructionOverlay");
+        instance = go.AddComponent<InstructionOverlay>();
+    }
+}

--- a/Assets/Scripts/InstructionOverlay.cs.meta
+++ b/Assets/Scripts/InstructionOverlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5d58098a8b847acbf1e4960ec4946e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MapGenerator.cs
+++ b/Assets/Scripts/MapGenerator.cs
@@ -7,6 +7,7 @@ using UnityEngine.Experimental.AI;
 
 public class MapGenerator : MonoBehaviour
 {
+    private const int startingIndex = 45;
     private int[] floorPlan;
     public int[] getFloorPlan => floorPlan;
 
@@ -28,6 +29,7 @@ public class MapGenerator : MonoBehaviour
     public List<Cell> getSpawnedCells => spawnedCells;
 
     private List<int> bigRoomIndexes;
+    private GameObject playerInstance;
 
     [Header("Sprite References")]
     [SerializeField] private Sprite item;
@@ -110,7 +112,7 @@ public class MapGenerator : MonoBehaviour
         endRooms = new List<int>();
         bigRoomIndexes = new List<int>();
 
-        VisitCell(45);
+        VisitCell(startingIndex);
 
         GenerateDungeon();
     }
@@ -149,7 +151,7 @@ public class MapGenerator : MonoBehaviour
         endRooms.RemoveAll(item => bigRoomIndexes.Contains(item) || GetNeighbourCount(item) > 1);
     }
 
-    void SetupSpecialRooms() 
+    void SetupSpecialRooms()
     {
         bossRoomIndex = endRooms.Count > 0 ? endRooms[endRooms.Count - 1] : -1;
 
@@ -172,6 +174,31 @@ public class MapGenerator : MonoBehaviour
 
         UpdateSpecialRoomVisuals();
         RoomManager.instance.SetupRooms(spawnedCells);
+        SpawnPlayer();
+    }
+
+    void SpawnPlayer()
+    {
+        if (playerInstance == null)
+        {
+            playerInstance = PlayerController.Create();
+            if (CameraFollow.instance != null)
+                CameraFollow.instance.target = playerInstance.transform;
+        }
+        if (!RoomManager.instance.TryGetRoom(startingIndex, out var spawnRoom))
+        {
+            playerInstance.transform.position = Vector2.zero;
+            return;
+        }
+
+        var spawnPosition = spawnRoom.GetSpawnPoint();
+        playerInstance.transform.position = spawnPosition;
+
+        var controller = playerInstance.GetComponent<PlayerController>();
+        controller.SetCurrentRoom(startingIndex);
+
+        RoomManager.instance.MarkStartRoom(startingIndex);
+        RoomManager.instance.NotifyPlayerEntered(startingIndex, controller);
     }
 
     void UpdateSpecialRoomVisuals() 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -1,0 +1,150 @@
+using System;
+using UnityEngine;
+
+public class PlayerController : MonoBehaviour
+{
+    public float speed = 5f;
+    public float projectileSpeed = 12f;
+    public float projectileLifetime = 1.5f;
+
+    private Rigidbody2D rb;
+    private SpriteRenderer sr;
+    private CircleCollider2D bodyCollider;
+    private Sprite[] frames;
+    private int direction; //0-down,1-left,2-right,3-up
+    private int animFrame;
+    private float animTimer;
+    private PlayerProjectileFactory projectileFactory;
+
+    public int CurrentRoomIndex { get; private set; } = -1;
+
+    private static readonly string spriteBase64 = "iVBORw0KGgoAAAANSUhEUgAAAIAAAAAQCAYAAADeWHeIAAAAiElEQVR4nO3VSwqAMAxF0ex/Zd1VxYGD2rQEkb5+7gNx4klD0GhGCCGE+MkpZfxh/katC7+57+FIEfzaXt4AvniuuI/w0wzg3fRo7xipHzL/CO4Vwa/tw0Wa+EdvbADJ/OX/IPUATvfyBvDiF+ApYvVXG8NWr2ELrj/On+N8r5nPwa/tCSE75wL1jq4JKFYPCQAAAABJRU5ErkJggg==";
+
+    public static GameObject Create()
+    {
+        var go = new GameObject("Player");
+        go.AddComponent<PlayerController>();
+        return go;
+    }
+
+    void Awake()
+    {
+        rb = gameObject.AddComponent<Rigidbody2D>();
+        rb.gravityScale = 0;
+        rb.constraints = RigidbodyConstraints2D.FreezeRotation;
+        bodyCollider = gameObject.AddComponent<CircleCollider2D>();
+        bodyCollider.radius = 0.3f;
+        bodyCollider.isTrigger = false;
+        sr = gameObject.AddComponent<SpriteRenderer>();
+        LoadSprites();
+        projectileFactory = new PlayerProjectileFactory();
+    }
+
+    void LoadSprites()
+    {
+        var bytes = Convert.FromBase64String(spriteBase64);
+        var tex = new Texture2D(0, 0) { filterMode = FilterMode.Point };
+        tex.LoadImage(bytes);
+
+        frames = new Sprite[8];
+        int w = 16; int h = 16;
+        for (int i = 0; i < 8; i++)
+        {
+            frames[i] = Sprite.Create(tex, new Rect(i * w, 0, w, h), new Vector2(0.5f, 0.5f), 16);
+        }
+        sr.sprite = frames[0];
+    }
+
+    void Update()
+    {
+        HandleMovement();
+        HandleShooting();
+    }
+
+    private void HandleMovement()
+    {
+        Vector2 input = new Vector2(Input.GetAxisRaw("Horizontal"), Input.GetAxisRaw("Vertical"));
+        input = input.normalized;
+        rb.velocity = input * speed;
+
+        if (input != Vector2.zero)
+        {
+            if (Mathf.Abs(input.x) > Mathf.Abs(input.y))
+                direction = input.x > 0 ? 2 : 1;
+            else
+                direction = input.y > 0 ? 3 : 0;
+
+            animTimer += Time.deltaTime;
+            if (animTimer > 0.2f)
+            {
+                animFrame = 1 - animFrame;
+                animTimer = 0f;
+            }
+        }
+        else
+        {
+            animFrame = 0;
+        }
+
+        sr.sprite = frames[direction * 2 + animFrame];
+    }
+
+    private void HandleShooting()
+    {
+        if (Input.GetKeyDown(KeyCode.UpArrow))
+        {
+            FireProjectile(Vector2.up);
+        }
+        else if (Input.GetKeyDown(KeyCode.DownArrow))
+        {
+            FireProjectile(Vector2.down);
+        }
+        else if (Input.GetKeyDown(KeyCode.LeftArrow))
+        {
+            FireProjectile(Vector2.left);
+        }
+        else if (Input.GetKeyDown(KeyCode.RightArrow))
+        {
+            FireProjectile(Vector2.right);
+        }
+    }
+
+    private void FireProjectile(Vector2 direction)
+    {
+        if (direction == Vector2.zero) return;
+        var projectile = projectileFactory.Spawn(transform.position, direction.normalized * projectileSpeed, projectileLifetime);
+        projectile.IgnoreCollisionWith(gameObject);
+    }
+
+    public void SetCurrentRoom(int index)
+    {
+        CurrentRoomIndex = index;
+    }
+
+    private class PlayerProjectileFactory
+    {
+        private readonly Sprite projectileSprite;
+
+        public PlayerProjectileFactory()
+        {
+            projectileSprite = LoadProjectileSprite();
+        }
+
+        public Projectile Spawn(Vector2 position, Vector2 velocity, float lifetime)
+        {
+            var projectile = Projectile.Create(projectileSprite);
+            projectile.transform.position = position;
+            projectile.Initialize(velocity, lifetime);
+            return projectile;
+        }
+
+        private Sprite LoadProjectileSprite()
+        {
+            const string data = "iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAP0lEQVR42mP8z8DwnwENgImBRRhGgGE0wWigG4KSRQBpBmYxkGE0QXQyaIphNBwmiDAGk2mAaQYmAAASD0D9Z7T2LgAAAABJRU5ErkJggg==";
+            var bytes = Convert.FromBase64String(data);
+            var tex = new Texture2D(0, 0) { filterMode = FilterMode.Point };
+            tex.LoadImage(bytes);
+            return Sprite.Create(tex, new Rect(0, 0, tex.width, tex.height), new Vector2(0.5f, 0.5f), tex.width);
+        }
+    }
+}

--- a/Assets/Scripts/PlayerController.cs.meta
+++ b/Assets/Scripts/PlayerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efe1c6d4abe241868ffd79d53cc47ada
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+
+public class Projectile : MonoBehaviour
+{
+    private Vector2 velocity;
+    private float lifetime;
+    private float timeAlive;
+    private SpriteRenderer spriteRenderer;
+    private Rigidbody2D rb;
+    private CircleCollider2D hitbox;
+
+    public static Projectile Create(Sprite sprite)
+    {
+        var go = new GameObject("PlayerProjectile");
+        var projectile = go.AddComponent<Projectile>();
+        projectile.InitializeGraphics(sprite);
+        return projectile;
+    }
+
+    private void InitializeGraphics(Sprite sprite)
+    {
+        spriteRenderer = gameObject.AddComponent<SpriteRenderer>();
+        spriteRenderer.sprite = sprite;
+        spriteRenderer.sortingOrder = 10;
+
+        rb = gameObject.AddComponent<Rigidbody2D>();
+        rb.gravityScale = 0f;
+        rb.isKinematic = true;
+
+        hitbox = gameObject.AddComponent<CircleCollider2D>();
+        hitbox.isTrigger = true;
+        hitbox.radius = 0.2f;
+    }
+
+    public void Initialize(Vector2 newVelocity, float newLifetime)
+    {
+        velocity = newVelocity;
+        lifetime = newLifetime;
+        timeAlive = 0f;
+    }
+
+    private void Update()
+    {
+        transform.position += (Vector3)(velocity * Time.deltaTime);
+        timeAlive += Time.deltaTime;
+        if (timeAlive >= lifetime)
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    public void IgnoreCollisionWith(GameObject owner)
+    {
+        var ownerColliders = owner.GetComponents<Collider2D>();
+        foreach (var ownerCollider in ownerColliders)
+        {
+            Physics2D.IgnoreCollision(hitbox, ownerCollider, true);
+        }
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.GetComponent<PlayerController>() != null)
+            return;
+
+        var enemy = other.GetComponent<EnemyController>();
+        if (enemy != null)
+        {
+            enemy.TakeDamage();
+            Destroy(gameObject);
+            return;
+        }
+
+        if (!other.isTrigger)
+        {
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Projectile.cs.meta
+++ b/Assets/Scripts/Projectile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 160d592ebe5a48139c2e361cb457d78e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Room.cs
+++ b/Assets/Scripts/Room.cs
@@ -1,7 +1,5 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Unity.VisualScripting;
 using UnityEngine;
 
 public enum EdgeDirection
@@ -16,11 +14,33 @@ public class Room : MonoBehaviour
 {
     public SpriteRenderer spriteRenderer;
 
+    private Dictionary<EdgeDirection, List<Door>> doorsByDirection;
+    private bool collidersBuilt;
+    private bool isStartRoom;
+    private bool hasCachedBounds;
+    private Rect cachedMovementBounds;
+    private EnemyController enemyInstance;
+    private bool shouldSpawnEnemy;
+
+    private void Awake()
+    {
+        doorsByDirection = new Dictionary<EdgeDirection, List<Door>>();
+    }
+
     public void SetupRoom(Cell currentCell, RoomScriptable room)
     {
         spriteRenderer.sprite = room.roomVariations[Random.Range(0, room.roomVariations.Length)];
 
-        if (currentCell.roomType == RoomType.Secret) return;
+        shouldSpawnEnemy = currentCell.roomType == RoomType.Regular;
+        doorsByDirection.Clear();
+        collidersBuilt = false;
+        hasCachedBounds = false;
+
+        if (currentCell.roomType == RoomType.Secret)
+        {
+            BuildWallColliders();
+            return;
+        }
 
         var floorplan = MapGenerator.instance.getFloorPlan;
         var cellList = MapGenerator.instance.getSpawnedCells;
@@ -46,9 +66,59 @@ public class Room : MonoBehaviour
             case RoomShape.LShape:
                 SetupLShapeRoom(currentCell, floorplan, cellList);
                 break;
+        }
 
-            default:
-                break;
+        BuildWallColliders();
+    }
+
+    public Vector2 GetSpawnPoint()
+    {
+        return transform.position;
+    }
+
+    public void MarkAsStartRoom()
+    {
+        isStartRoom = true;
+        InstructionOverlay.Show();
+    }
+
+    public void OnPlayerEntered(PlayerController player)
+    {
+        if (isStartRoom)
+        {
+            InstructionOverlay.Show();
+        }
+        else
+        {
+            InstructionOverlay.Hide();
+        }
+
+        HandleEnemySpawn(player);
+    }
+
+    public void OnPlayerExited()
+    {
+        if (isStartRoom)
+        {
+            InstructionOverlay.Hide();
+        }
+
+        if (enemyInstance != null)
+        {
+            enemyInstance.SetActive(false);
+        }
+    }
+
+    public void RefreshPlayerReference(PlayerController player)
+    {
+        if (enemyInstance != null)
+        {
+            enemyInstance.Configure(player.transform, GetMovementBounds());
+        }
+
+        if (isStartRoom)
+        {
+            InstructionOverlay.Show();
         }
     }
 
@@ -174,19 +244,35 @@ public class Room : MonoBehaviour
     {
         int neighbourIndex = fromIndex + GetOffset(direction);
 
-        if (neighbourIndex < 0 || neighbourIndex >= floorplan.Length) return;
+        if (neighbourIndex < 0 || neighbourIndex >= floorplan.Length)
+            return;
 
-        if (floorplan[neighbourIndex] != 1) return;
+        if (floorplan[neighbourIndex] != 1)
+            return;
 
         var foundCell = cellList.FirstOrDefault(x => x.cellList.Contains(neighbourIndex));
 
-        if (foundCell.roomType == RoomType.Secret) return;
+        if (foundCell.roomType == RoomType.Secret)
+            return;
 
         var door = Instantiate(RoomManager.instance.doorPrefab, transform);
-
         door.transform.position = (Vector2)transform.position + positionOffset;
 
+        RegisterDoor(door, direction, fromIndex, neighbourIndex);
         SetupDoor(door, direction, currentCell.roomType == RoomType.Regular ? foundCell.roomType : currentCell.roomType);
+    }
+
+    private void RegisterDoor(Door door, EdgeDirection direction, int fromIndex, int neighbourIndex)
+    {
+        if (!doorsByDirection.TryGetValue(direction, out var list))
+        {
+            list = new List<Door>();
+            doorsByDirection.Add(direction, list);
+        }
+
+        list.Add(door);
+        door.SetDirection(direction);
+        door.SetConnection(fromIndex, neighbourIndex);
     }
 
     private void SetupDoor(Door door, EdgeDirection direction, RoomType roomType)
@@ -209,9 +295,6 @@ public class Room : MonoBehaviour
 
             case EdgeDirection.Right:
                 door.SetDoorSprite(doorTypes.rightDoor);
-                break;
-
-            default:
                 break;
         }
     }
@@ -239,5 +322,128 @@ public class Room : MonoBehaviour
         }
 
         return 0;
+    }
+
+    private void HandleEnemySpawn(PlayerController player)
+    {
+        if (!shouldSpawnEnemy)
+            return;
+
+        var bounds = GetMovementBounds();
+
+        if (enemyInstance == null)
+        {
+            enemyInstance = EnemyController.Create();
+            enemyInstance.transform.SetParent(transform);
+            enemyInstance.transform.position = bounds.center;
+        }
+
+        enemyInstance.Configure(player.transform, bounds);
+    }
+
+    private Rect GetMovementBounds()
+    {
+        if (!hasCachedBounds)
+        {
+            var bounds = spriteRenderer.bounds;
+            const float margin = 0.6f;
+            var width = Mathf.Max(0.5f, bounds.size.x - margin * 2f);
+            var height = Mathf.Max(0.5f, bounds.size.y - margin * 2f);
+            cachedMovementBounds = new Rect(bounds.min.x + margin, bounds.min.y + margin, width, height);
+            hasCachedBounds = true;
+        }
+
+        return cachedMovementBounds;
+    }
+
+    private void BuildWallColliders()
+    {
+        if (collidersBuilt)
+            return;
+
+        collidersBuilt = true;
+
+        var worldBounds = spriteRenderer.bounds;
+        var left = worldBounds.min.x - transform.position.x;
+        var right = worldBounds.max.x - transform.position.x;
+        var bottom = worldBounds.min.y - transform.position.y;
+        var top = worldBounds.max.y - transform.position.y;
+        const float thickness = 0.6f;
+
+        BuildHorizontalWall(EdgeDirection.Up, top - thickness * 0.5f, left, right, thickness);
+        BuildHorizontalWall(EdgeDirection.Down, bottom + thickness * 0.5f, left, right, thickness);
+        BuildVerticalWall(EdgeDirection.Left, left + thickness * 0.5f, bottom, top, thickness);
+        BuildVerticalWall(EdgeDirection.Right, right - thickness * 0.5f, bottom, top, thickness);
+    }
+
+    private void BuildHorizontalWall(EdgeDirection direction, float y, float left, float right, float thickness)
+    {
+        CreateWallSegments(direction, y, left, right, thickness, true);
+    }
+
+    private void BuildVerticalWall(EdgeDirection direction, float x, float bottom, float top, float thickness)
+    {
+        CreateWallSegments(direction, x, bottom, top, thickness, false);
+    }
+
+    private void CreateWallSegments(EdgeDirection direction, float constant, float min, float max, float thickness, bool horizontal)
+    {
+        var gaps = new List<(float start, float end)>();
+        if (doorsByDirection.TryGetValue(direction, out var doorList))
+        {
+            foreach (var door in doorList)
+            {
+                var local = door.transform.localPosition;
+                var size = door.GetSize();
+                var half = (horizontal ? size.x : size.y) * 0.5f + 0.25f;
+                var center = horizontal ? local.x : local.y;
+
+                var gapStart = Mathf.Max(min, center - half);
+                var gapEnd = Mathf.Min(max, center + half);
+                if (gapEnd <= min || gapStart >= max)
+                    continue;
+
+                gaps.Add((gapStart, gapEnd));
+            }
+        }
+
+        gaps.Sort((a, b) => a.start.CompareTo(b.start));
+
+        var cursor = min;
+        foreach (var gap in gaps)
+        {
+            if (gap.start > cursor)
+            {
+                CreateCollider(cursor, Mathf.Min(gap.start, max), constant, thickness, horizontal);
+            }
+
+            cursor = Mathf.Max(cursor, gap.end);
+            if (cursor >= max)
+                break;
+        }
+
+        if (cursor < max)
+        {
+            CreateCollider(cursor, max, constant, thickness, horizontal);
+        }
+    }
+
+    private void CreateCollider(float start, float end, float constant, float thickness, bool horizontal)
+    {
+        var length = end - start;
+        if (length <= 0.05f)
+            return;
+
+        var collider = gameObject.AddComponent<BoxCollider2D>();
+        if (horizontal)
+        {
+            collider.size = new Vector2(length, thickness);
+            collider.offset = new Vector2((start + end) * 0.5f, constant);
+        }
+        else
+        {
+            collider.size = new Vector2(thickness, length);
+            collider.offset = new Vector2(constant, (start + end) * 0.5f);
+        }
     }
 }

--- a/Assets/Scripts/RoomManager.cs
+++ b/Assets/Scripts/RoomManager.cs
@@ -7,6 +7,8 @@ using UnityEngine;
 public class RoomManager : MonoBehaviour
 {
     private List<Room> createdRooms;
+    private Dictionary<int, Room> roomsByCellIndex;
+    private Room currentRoom;
 
     [Header("Offset Variables")]
     public float offsetX;
@@ -26,6 +28,7 @@ public class RoomManager : MonoBehaviour
     {
         instance = this;
         createdRooms = new List<Room>();
+        roomsByCellIndex = new Dictionary<int, Room>();
     }
 
     public void SetupRooms(List<Cell> spawnedCells)
@@ -36,6 +39,8 @@ public class RoomManager : MonoBehaviour
         }
 
         createdRooms.Clear();
+        roomsByCellIndex.Clear();
+        currentRoom = null;
 
         foreach(var currentCell in spawnedCells)
         {
@@ -49,7 +54,49 @@ public class RoomManager : MonoBehaviour
 
             spawnedRoom.SetupRoom(currentCell, foundRoom);
 
+            foreach (var index in currentCell.cellList)
+            {
+                roomsByCellIndex[index] = spawnedRoom;
+            }
+
             createdRooms.Add(spawnedRoom);
+        }
+    }
+
+    public bool TryGetRoom(int cellIndex, out Room room)
+    {
+        return roomsByCellIndex.TryGetValue(cellIndex, out room);
+    }
+
+    public Vector2 GetRoomCenter(int cellIndex)
+    {
+        return roomsByCellIndex.TryGetValue(cellIndex, out var room) ? room.GetSpawnPoint() : Vector2.zero;
+    }
+
+    public void NotifyPlayerEntered(int cellIndex, PlayerController player)
+    {
+        if (!roomsByCellIndex.TryGetValue(cellIndex, out var room))
+            return;
+
+        if (currentRoom == room)
+        {
+            if (room != null)
+            {
+                room.RefreshPlayerReference(player);
+            }
+            return;
+        }
+
+        currentRoom?.OnPlayerExited();
+        currentRoom = room;
+        currentRoom.OnPlayerEntered(player);
+    }
+
+    public void MarkStartRoom(int cellIndex)
+    {
+        if (roomsByCellIndex.TryGetValue(cellIndex, out var room))
+        {
+            room.MarkAsStartRoom();
         }
     }
 


### PR DESCRIPTION
## Summary
- track the generated start room so the player spawns inside it, shows a guidance overlay, and moves between rooms via the room manager
- add runtime-built wall colliders and an enemy spawner that activates when rooms are entered
- give the player basic projectile attacks with a new projectile component and simple enemy AI

## Testing
- Not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68c02913bec4833188576caccbbb7abe