### PR TITLE
Add door locking system and room door controls

### DIFF
--- a/Assets/Scripts/Door.cs
+++ b/Assets/Scripts/Door.cs
@@ -2,22 +2,34 @@ using UnityEngine;
 
 public class Door : MonoBehaviour
 {
-    public SpriteRenderer spriteRenderer;
+    [SerializeField] private SpriteRenderer spriteRenderer;
+    [SerializeField] private Sprite closedDoorSprite;
+
     private EdgeDirection direction;
+    private BoxCollider2D boxCollider;
+    private Sprite openDoorSprite;
+
+    public bool isLocked { get; private set; }
 
     private void Awake()
     {
-        var col = GetComponent<Collider2D>();
-        if (col == null)
+        boxCollider = GetComponent<BoxCollider2D>();
+        if (boxCollider == null)
         {
-            var box = gameObject.AddComponent<BoxCollider2D>();
-            box.isTrigger = true;
+            boxCollider = gameObject.AddComponent<BoxCollider2D>();
         }
+
+        boxCollider.isTrigger = true;
     }
 
     public void SetDoorSprite(Sprite door)
     {
-        spriteRenderer.sprite = door;
+        openDoorSprite = door;
+
+        if (!isLocked)
+        {
+            spriteRenderer.sprite = door;
+        }
     }
 
     public void SetDirection(EdgeDirection dir)
@@ -25,8 +37,44 @@ public class Door : MonoBehaviour
         direction = dir;
     }
 
+    public void Lock()
+    {
+        if (isLocked) return;
+
+        isLocked = true;
+
+        if (closedDoorSprite != null)
+        {
+            spriteRenderer.sprite = closedDoorSprite;
+        }
+
+        if (boxCollider != null)
+        {
+            boxCollider.isTrigger = false;
+        }
+    }
+
+    public void Unlock()
+    {
+        if (!isLocked) return;
+
+        isLocked = false;
+
+        if (openDoorSprite != null)
+        {
+            spriteRenderer.sprite = openDoorSprite;
+        }
+
+        if (boxCollider != null)
+        {
+            boxCollider.isTrigger = true;
+        }
+    }
+
     private void OnTriggerEnter2D(Collider2D other)
     {
+        if (isLocked) return;
+
         var player = other.GetComponent<PlayerController>();
         if (player == null) return;
 

--- a/Assets/Scripts/Room.cs
+++ b/Assets/Scripts/Room.cs
@@ -15,9 +15,23 @@ public enum EdgeDirection
 public class Room : MonoBehaviour
 {
     public SpriteRenderer spriteRenderer;
+    [SerializeField] private bool autoUnlockOnStart = true;
+
+    private readonly List<Door> spawnedDoors = new List<Door>();
+
+    private void Start()
+    {
+        LockDoors();
+
+        if (autoUnlockOnStart)
+        {
+            UnlockDoors();
+        }
+    }
 
     public void SetupRoom(Cell currentCell, RoomScriptable room)
     {
+        spawnedDoors.Clear();
         spriteRenderer.sprite = room.roomVariations[Random.Range(0, room.roomVariations.Length)];
 
         if (currentCell.roomType == RoomType.Secret) return;
@@ -187,6 +201,8 @@ public class Room : MonoBehaviour
         door.transform.position = (Vector2)transform.position + positionOffset;
 
         SetupDoor(door, direction, currentCell.roomType == RoomType.Regular ? foundCell.roomType : currentCell.roomType);
+
+        spawnedDoors.Add(door);
     }
 
     private void SetupDoor(Door door, EdgeDirection direction, RoomType roomType)
@@ -216,6 +232,26 @@ public class Room : MonoBehaviour
         }
 
         door.SetDirection(direction);
+    }
+
+    public void LockDoors()
+    {
+        foreach (var door in spawnedDoors)
+        {
+            if (door == null) continue;
+
+            door.Lock();
+        }
+    }
+
+    public void UnlockDoors()
+    {
+        foreach (var door in spawnedDoors)
+        {
+            if (door == null) continue;
+
+            door.Unlock();
+        }
     }
 
     private DoorScriptable GetDoorOptions(RoomType roomType)


### PR DESCRIPTION
## Summary
- add locking state to doors that toggles sprites and collider behaviour while locked
- track doors spawned by each room and expose helpers to lock or unlock them
- provide an optional auto-unlock flag to demonstrate the locking flow until combat hooks are added

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68da89db49c483319c90014eb4ff0d8e