### PR TITLE
Add spawn anchor support for generated rooms

### DIFF
--- a/Assets/Room.prefab
+++ b/Assets/Room.prefab
@@ -29,7 +29,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1309804014946158558}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -95,6 +96,38 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 61e5b98ef9608c246bcfcc0d2beb9327, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   spriteRenderer: {fileID: 5355932114863003626}
+  spawnAnchor: {fileID: 1309804014946158558}
+--- !u!1 &4600577967052142984
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1309804014946158558}
+  m_Layer: 0
+  m_Name: SpawnAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1309804014946158558
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4600577967052142984}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5453348919352033792}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/MapGenerator.cs
+++ b/Assets/Scripts/MapGenerator.cs
@@ -27,6 +27,9 @@ public class MapGenerator : MonoBehaviour
 
     public List<Cell> getSpawnedCells => spawnedCells;
 
+    [Header("Spawn Settings")]
+    [SerializeField] private int startCellIndex = 45;
+
     private List<int> bigRoomIndexes;
     private GameObject playerInstance;
 
@@ -111,7 +114,7 @@ public class MapGenerator : MonoBehaviour
         endRooms = new List<int>();
         bigRoomIndexes = new List<int>();
 
-        VisitCell(45);
+        VisitCell(GetInitialCellIndex());
 
         GenerateDungeon();
     }
@@ -184,7 +187,30 @@ public class MapGenerator : MonoBehaviour
             if (CameraFollow.instance != null)
                 CameraFollow.instance.target = playerInstance.transform;
         }
-        playerInstance.transform.position = Vector2.zero;
+        Cell spawnCell = spawnedCells.FirstOrDefault(cell => cell.cellList.Contains(startCellIndex));
+
+        if (spawnCell == null)
+        {
+            spawnCell = spawnedCells.FirstOrDefault();
+        }
+
+        Vector3 spawnPosition = Vector3.zero;
+
+        if (spawnCell != null)
+        {
+            var spawnAnchor = RoomManager.instance?.GetSpawnAnchor(spawnCell);
+
+            if (spawnAnchor != null)
+            {
+                spawnPosition = spawnAnchor.position;
+            }
+            else
+            {
+                spawnPosition = spawnCell.transform.position;
+            }
+        }
+
+        playerInstance.transform.position = spawnPosition;
     }
 
     void UpdateSpecialRoomVisuals() 
@@ -406,5 +432,20 @@ public class MapGenerator : MonoBehaviour
         newCell.cellList = largeRoomIndexes;
         newCell.cellList.Sort();
         spawnedCells.Add(newCell);
+    }
+
+    private int GetInitialCellIndex()
+    {
+        int candidate = Mathf.Clamp(startCellIndex, 0, floorPlan.Length - 1);
+
+        return IsIndexInBounds(candidate) ? candidate : 45;
+    }
+
+    private static bool IsIndexInBounds(int index)
+    {
+        int x = index % 10;
+        int y = index / 10;
+
+        return x > 0 && x < 9 && y > 0 && y < 9;
     }
 }

--- a/Assets/Scripts/Room.cs
+++ b/Assets/Scripts/Room.cs
@@ -15,6 +15,9 @@ public enum EdgeDirection
 public class Room : MonoBehaviour
 {
     public SpriteRenderer spriteRenderer;
+    [SerializeField] private Transform spawnAnchor;
+
+    public Transform SpawnAnchor => spawnAnchor;
 
     public void SetupRoom(Cell currentCell, RoomScriptable room)
     {

--- a/Assets/Scripts/RoomManager.cs
+++ b/Assets/Scripts/RoomManager.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 public class RoomManager : MonoBehaviour
 {
     private List<Room> createdRooms;
+    private readonly Dictionary<Cell, Room> cellToRoomMap = new();
 
     [Header("Offset Variables")]
     public float offsetX;
@@ -36,6 +37,7 @@ public class RoomManager : MonoBehaviour
         }
 
         createdRooms.Clear();
+        cellToRoomMap.Clear();
 
         foreach(var currentCell in spawnedCells)
         {
@@ -50,7 +52,23 @@ public class RoomManager : MonoBehaviour
             spawnedRoom.SetupRoom(currentCell, foundRoom);
 
             createdRooms.Add(spawnedRoom);
+            cellToRoomMap[currentCell] = spawnedRoom;
         }
+    }
+
+    public Transform GetSpawnAnchor(Cell cell)
+    {
+        if (cell == null)
+        {
+            return null;
+        }
+
+        if (cellToRoomMap.TryGetValue(cell, out var room))
+        {
+            return room.SpawnAnchor;
+        }
+
+        return null;
     }
 
     private bool DoesTileMatchCell(int[] occupiedTiles, Cell cell)


### PR DESCRIPTION
## Summary
- allow designers to pick a starting cell index and derive the player spawn point from room spawn anchors
- cache the relationship between generated cells and instantiated rooms to query dedicated spawn anchors
- extend the Room prefab with a spawn anchor transform used when placing the player

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68da89da6dc88331962738672f84c5f5