### PR TITLE
Expose room spawn anchor

### DIFF
--- a/Assets/Scripts/Room.cs
+++ b/Assets/Scripts/Room.cs
@@ -16,9 +16,12 @@ public class Room : MonoBehaviour
 {
     public SpriteRenderer spriteRenderer;
 
+    [SerializeField] private Transform spawnAnchor;
     [SerializeField] private bool autoUnlockOnStart = true;
 
     private readonly List<Door> spawnedDoors = new List<Door>();
+
+    public Transform SpawnAnchor => spawnAnchor;
 
     private void Start()
     {


### PR DESCRIPTION
## Summary
- add a serialized spawn anchor reference to Room
- expose the spawn anchor via a public property so RoomManager can access it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3c25c92308331b74af4b647b2d3b0