### PR TITLE
Ensure player sprite renders above environment

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -27,6 +27,8 @@ public class PlayerController : MonoBehaviour
         rb.gravityScale = 0;
         rb.constraints = RigidbodyConstraints2D.FreezeRotation;
         sr = gameObject.AddComponent<SpriteRenderer>();
+        sr.sortingLayerName = "Characters";
+        sr.sortingOrder = 10;
         LoadSprites();
     }
 


### PR DESCRIPTION
## Summary
- set the player sprite renderer to use the Characters sorting layer at a higher order

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e50e5769d88331b1262dcc66de0489